### PR TITLE
download url update

### DIFF
--- a/bs4/whocc.py
+++ b/bs4/whocc.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 
 class WHOCCAtcDddIndex:
     def __init__(self, loop=None):
-        self.ACT_DDD_ROOT = "https://www.whocc.no/atc_ddd_index"
+        self.ACT_DDD_ROOT = "https://atcddd.fhi.no/atc_ddd_index"
         self.ATC_RE = r"([\w\d]+)\s+\<b\>\<a\s?href\=\"\.(\/\?.+?)\">([\w\s\.\\\/\,\-\(\)]+)\<\/a\>"
         self.parse = BeautifulSoup
         self.client = httpx.AsyncClient()


### PR DESCRIPTION
The site is moved from "https://www.whocc.no/atc_ddd_index" to "https://atcddd.fhi.no/atc_ddd_index", so changing the URL is required.